### PR TITLE
Update shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                     <h4>Shell</h4>
                     <ul>
                         <li>
-                            <code>Shift + Up</code> : Traverse up in directory structure (lovely feature!)</li>
+                            <code>Ctrl + Alt + u</code> : Traverse up in directory structure (lovely feature!)</li>
                         <li>
                             <code>End, Home, Ctrl</code> : Traverse text as usual on Windows</li>
                         <li>


### PR DESCRIPTION
The shortcut to "Traverse up in directory structure" is correct in the readme, but not on the main site. This fixes the discrepancy.