### PR TITLE
Fixed #1563, Added dynamic size

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
                     <a id="mini" onclick="_gaq.push(['_trackEvent', 'Download', 'mini'])" href="https://github.com/cmderdev/cmder/releases/latest">
                         <button class="gray">Download Mini</button>
                     </a>
-                    <small is="mini-size">~7.8MB</small>
+                    <small id="mini-size">~7.8MB</small>
                 </div>
                 <div class="bit-2">
                     <a id="full" onclick="_gaq.push(['_trackEvent', 'Download', 'full'])" href="https://github.com/cmderdev/cmder/releases/latest">

--- a/index.html
+++ b/index.html
@@ -75,15 +75,15 @@
                     <a id="mini" onclick="_gaq.push(['_trackEvent', 'Download', 'mini'])" href="https://github.com/cmderdev/cmder/releases/latest">
                         <button class="gray">Download Mini</button>
                     </a>
-                    <small>~7.8MB</small>
+                    <small is="mini-size">~7.8MB</small>
                 </div>
                 <div class="bit-2">
                     <a id="full" onclick="_gaq.push(['_trackEvent', 'Download', 'full'])" href="https://github.com/cmderdev/cmder/releases/latest">
                         <button class="blue">Download Full</button>
                     </a>
-                    <small>(With Git for Windows) ~100MB</small>
+                    <small>(With Git for Windows) <span id="full-size">~100MB</span></small>
                     <small>
-                        <em><a id="7z" onclick="_gaq.push(['_trackEvent', 'Download', 'full', '7z'])" href="https://github.com/cmderdev/cmder/releases/latest">~52MB 7z</a></em>
+                        <em><a id="7z" onclick="_gaq.push(['_trackEvent', 'Download', 'full', '7z'])" href="https://github.com/cmderdev/cmder/releases/latest"><span id="7z-size">~52MB</span> 7z</a></em>
                     </small>
                 </div>
 
@@ -200,6 +200,12 @@
         $(document).ready(function () {
             getLatestReleases();
         })
+        
+        function getSizeInMb( bytes, decimal ) {
+            var decimal = decimal || 0;
+            var size = (bytes / Math.pow(2, 20));
+            return '~' + ( decimal == 0 ? Math.ceil(size) : size.toFixed(decimal) ) + 'MB';
+        }
 
         function getLatestReleases() {
             $.getJSON("https://api.github.com/repos/cmderdev/cmder/releases/latest").done(function (release) {
@@ -207,10 +213,16 @@
                     switch (asset.name) {
                         case "cmder.zip":
                             $("#full").attr("href", asset.browser_download_url);
+                            $("#full-size").html( getSizeInMb(asset.size) );
+                            break;
                         case "cmder_mini.zip":
                             $("#mini").attr("href", asset.browser_download_url);
+                            $("#mini-size").html( getSizeInMb(asset.size, 1) );
+                            break;
                         case "cmder.7z":
                             $("#7z").attr("href", asset.browser_download_url);
+                            $("#7z-size").html( getSizeInMb(asset.size) );
+                            break;
                     }
                 }
             })


### PR DESCRIPTION
1. This patch fixes [issue #1563](https://github.com/cmderdev/cmder/issues/1563) (invalid url for the `.7z` link set), by adding `break` after each appropriate `case`.
2. Also, while the url is fetched from the GitHub api, the byte size is also fetched. Using `getSizeInMb()`, the correct size is also set.